### PR TITLE
Preserve current editor state when saving as a new file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Fixed window scrolling when moving the cursor at 200% zoom.
 - Fixed X-flipping for characters 184 (╕) and 213 (╒).
+- Fixed "Save as..." resetting the editor state and clearing the
+  undo/redo history for the current document.
 
 ## v3.1.0 (2025-04-05)
 

--- a/app/controller.js
+++ b/app/controller.js
@@ -61,29 +61,19 @@ function save(destroy_when_done = false, save_without_sauce = false) {
 async function save_as(destroy_when_done = false) {
     const file = save_box(doc.file, "xb", { filters: [{ name: "XBin", extensions: ["xb"] }, { name: "ANSI Art", extensions: ["ans", "asc", "diz", "nfo", "txt"] }, { name: "Binary Text", extensions: ["bin"] }] });
     if (!file) return;
-
-    if (file === doc.file) {
-        doc.file = file;
-        doc.edited = false;
-        save(destroy_when_done);
-    } else {
-        await doc.save_backup(file)
-        await doc.open(file);
-    }
+    doc.file = file;
+    doc.edited = false;
+    save(destroy_when_done);
+    send("set_file", { file: doc.file });
 }
 
 async function save_without_sauce() {
     const file = save_box(doc.file, "xb", { filters: [{ name: "XBin", extensions: ["xb"] }, { name: "ANSI Art", extensions: ["ans", "asc", "diz", "nfo", "txt"] }, { name: "Binary Text", extensions: ["bin"] }] });
     if (!file) return;
-
-    if (file === doc.file) {
-        doc.file = file;
-        doc.edited = false;
-        save(false, true);
-    } else {
-        await doc.save_backup_without_sauce(file)
-        await doc.open(file);
-    }
+    doc.file = file;
+    doc.edited = false;
+    save(false, true);
+    send("set_file", { file: doc.file });
 }
 
 async function export_font() {


### PR DESCRIPTION
Fixes #17 